### PR TITLE
Dont create glue trigger by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ resource "aws_glue_job" "default" {
 
 
 resource "aws_glue_trigger" "default" {
+  count = var.trigger_type != null ? 1 : 0
   name     = "${var.name}-${var.trigger_type}"
   enabled  = var.active
   schedule = var.schedule


### PR DESCRIPTION
This is done to address an issue where a glue `job trigger` is always created when a glue job is added. The default trigger type is `ON_DEMAND` as defined in the [glue template](https://github.com/sbpdvb/dataplatform-repo-templates/blob/main/tf-project/terraform/managed_by_dp_project_glue_job.tf#L36).
This creates following issues:
 - Unintentional job run: user always gets an ON_DEMAND trigger which by default starts the glue job as soon as its deployed
 - the ON_DEMAND trigger is created with an invalid schedule 
![image](https://github.com/sbpdvb/terraform-aws-mcaf-glue/assets/148551333/3e0b168f-71bf-4e5f-bef6-8d7e56c31ea0)
 - Issues when removing jobs: We have seen multiple times that having an invalid cronjob leads to failures when removing jobs. So only workaround is to add a valid schedule and then remove the job.

This PR along [with](https://github.com/sbpdvb/dataplatform-repo-templates/pull/161) makes sure that a trigger is added only when a user explicitly wants it.